### PR TITLE
v3.0.35

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Drayton Wiser Hub API v2 v0.0.34
+# Drayton Wiser Hub API v2 v0.0.35
 
 This repository contains a simple API which queries the Drayton Wiser Heating sysystem used in the UK.
 
@@ -182,3 +182,8 @@ Documentation available in [info.md](https://github.com/msp1974/wiserHeatAPIv2/b
 
 ### 0.0.34
 - Fixed issue where create_schedule was passing wrong schedule type to hub
+
+### 0.0.35
+- Fixed issue whereby Level schedule can have no schedule data.  Return day data with empty slots
+- Fixed issue whereby Level schedule with no schedule data does not return schedule.next object
+- Ensure default empty schedule when creating Level schedule

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 
 setuptools.setup(
     name="wiserHeatAPIv2", # Replace with your own username
-    version="0.0.34",
+    version="0.0.35",
     author="Mark Parker",
     author_email="msparker@sky.com",
     description="An API for controlling the Drayton Wiser Heating system",

--- a/wiserHeatAPIv2/__init__.py
+++ b/wiserHeatAPIv2/__init__.py
@@ -1,7 +1,7 @@
 name = "wiser-heat-api-v2"
 __all__ = ["wiserAPI","wiserDiscovery"]
 
-__VERSION__ = "0.0.34"
+__VERSION__ = "0.0.35"
 
 import logging
 _LOGGER = logging.getLogger(__name__)

--- a/wiserHeatAPIv2/const.py
+++ b/wiserHeatAPIv2/const.py
@@ -75,3 +75,13 @@ WISERLIGHT = "Light/{}"
 class WiserUnitsEnum(enum.Enum):
     imperial = "imperial"
     metric = "metric"
+
+DEFAULT_LEVEL_SCHEDULE = {
+    "Monday": {"Time":[],"Level":[]},
+    "Tuesday": {"Time":[],"Level":[]},
+    "Wednesday": {"Time":[],"Level":[]},
+    "Thursday": {"Time":[],"Level":[]},
+    "Friday": {"Time":[],"Level":[]},
+    "Saturday": {"Time":[],"Level":[]},
+    "Sunday": {"Time":[],"Level":[]}
+}


### PR DESCRIPTION
- Fixed issue whereby Level schedule can have no schedule data.  Return day data with empty slots
- Fixed issue whereby Level schedule with no schedule data does not return schedule.next object
- Ensure default empty schedule when creating Level schedule